### PR TITLE
Java 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,5 +2,5 @@
 #  - openjdk17
 before_install:
   - sdk update
-  - sdk install java 17.0.3-tem
-  - sdk use java 17.0.3-tem
+  - sdk install java 21.0.6-tem
+  - sdk use java 21.0.6-tem

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <packaging>jar</packaging>
-    <jdk.version>17</jdk.version>
-    <release.version>17</release.version>
+    <jdk.version>21</jdk.version>
+    <release.version>21</release.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This pull request updates the Java Development Kit (JDK) version used in the project from 17 to 21. The most important changes include modifications to the `jitpack.yml` and `pom.xml` files to reflect this update.

JDK version update:

* [`jitpack.yml`](diffhunk://#diff-1604193a5efbe3735c6ab8b44601ad6e42df52f6834bcc155650e3eef5b3fa94L5-R6): Updated the JDK version from 17.0.3-tem to 21.0.6-tem.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L16-R20): Changed the Maven compiler source and target versions, as well as the JDK and release versions, from 17 to 21.