### PR TITLE
:arrow_up: Bump jackson to 2.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.3</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.1</version>
+      <version>2.18.3</version>
     </dependency>
 
     <!-- Jackson module for Java 8 date and time types -->

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.3</version>
     </dependency>
 
     <!-- Jackson module for JDK collections -->


### PR DESCRIPTION
This pull request includes a version update for several dependencies in the `pom.xml` file. The changes involve updating the versions of Jackson core libraries to ensure compatibility and possibly leverage new features or security fixes.

Dependency version updates:

* Updated `jackson-core` from `2.14.2` to `2.18.3`.
* Updated `jackson-databind` from `2.15.1` to `2.18.3`.
* Updated `jackson-datatype-jsr310` from `2.14.2` to `2.18.3`.
* Updated `jackson-datatype-jdk8` from `2.14.2` to `2.18.3`.