### PR TITLE
:arrow_up: Bump dependency cleanuri-site to 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-site</artifactId>
-      <version>0.1.0</version>
+      <version>0.2.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request includes an update to the `pom.xml` file to upgrade the version of the `cleanURI-site` dependency.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L38-R38): Updated `cleanURI-site` dependency version from `0.1.0` to `0.2.1`.