### PR TITLE
Fix detection for Reichelt URIs: idempotency

### DIFF
--- a/src/main/java/com/penguineering/cleanuri/site/implementations/reichelt/Uri2ArticleIdParser.java
+++ b/src/main/java/com/penguineering/cleanuri/site/implementations/reichelt/Uri2ArticleIdParser.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Uri2ArticleIdParser {
-    static final Pattern artidPattern = Pattern.compile("^http.*://www\\.reichelt\\.de/.*-p(.*)\\.html.*$");
+    static final Pattern artidPattern = Pattern.compile("^http.*://www\\.reichelt\\.de/index\\.html\\?ARTICLE=(.*)$");
     static final Pattern artidPattern2 = Pattern.compile("^http.*://www\\.reichelt\\.de/.*/produkt/.*-(\\d+)$");
 
     public Uri2ArticleIdParser() {

--- a/src/test/java/com/penguineering/cleanuri/site/implementations/reichelt/TestReicheltCanonizer.java
+++ b/src/test/java/com/penguineering/cleanuri/site/implementations/reichelt/TestReicheltCanonizer.java
@@ -24,6 +24,7 @@ class TestReicheltCanonizer {
      */
     @ParameterizedTest
     @CsvSource({
+            "'https://www.reichelt.de/index.html?ARTICLE=10228', 'https://www.reichelt.de/index.html?ARTICLE=10228'",
             "'https://www.reichelt.de/de/de/shop/produkt/led_3_mm_bedrahtet_rot_191_mcd_50_-10228', 'https://www.reichelt.de/index.html?ARTICLE=10228'",
             "'https://www.reichelt.de/de/de/shop/produkt/digital_thermometer_1-wire_-_0_5_c_so-8-58170', 'https://www.reichelt.de/index.html?ARTICLE=58170'",
             "'https://www.reichelt.de/non-parsable-uri', ''"


### PR DESCRIPTION
This pull request includes updates to the `Uri2ArticleIdParser` class and its corresponding test cases in the `TestReicheltCanonizer` class. In #10 there has been a mistake when replacing the regex, leading to  a missing regex for normalized URIs. Since there was also no test case for idempotent URIs, this bug has not been caught.

### Regex pattern update:

* [`src/main/java/com/penguineering/cleanuri/site/implementations/reichelt/Uri2ArticleIdParser.java`](diffhunk://#diff-c5e54b75a35d5b440f4b38fd1677bf6868ae630c7df2a905c54fa5aedeaee369L9-R9): Updated the `artidPattern` regex to match URLs in the format `https://www.reichelt.de/index.html?ARTICLE=(.*)`.

### Test cases update:

* [`src/test/java/com/penguineering/cleanuri/site/implementations/reichelt/TestReicheltCanonizer.java`](diffhunk://#diff-700e17fb8dcebcd6b040bac753eaa8b767d885a8fe6241f35d6f65710e029daeR27): Added a new test case for URLs in the format `https://www.reichelt.de/index.html?ARTICLE=10228` to ensure the updated regex pattern is correctly parsing article IDs.